### PR TITLE
feat: add a simple way to user defined port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ the fly:
 
 ```sh
 $ alias teecp='go run github.com/jeffque/teecp@latest'
-$ ./some-long-process | teecp --server=:6667 | grep "dodongo"
+$ ./some-long-process | teecp | grep "dodongo"
 ```
 
 For each other terminal (assumes that `alias teecp` has been applied):
 
 ```sh
-$ teecp --client=localhost:6667 | grep "bomb"  | teecp --server=:6668
+$ teecp --server=false | grep "bomb"  | teecp --port 6668
 ```
 
 ```sh
-$ teecp --client=localhost:6668 | wc -l
+$ teecp --server=false --port 6668 | wc -l
 ```
 
 ```sh
-$ teecp --client=localhost:6667 | grep "[Ll]ink"
+$ teecp --server=false | grep "[Ll]ink"
 ```
 
 ## Current status
 
 - [ ] Command line 
-- [ ] User selected port (for now is 6667)
+- [X] User selected port ~~(for now is 6667)~~
 - [ ] Alternate between client and server with something more beautiful

--- a/main.go
+++ b/main.go
@@ -5,24 +5,29 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"flag"
 
 	tcp "github.com/jeffque/teecp/teecp"
 )
 
 func main() {
-	port := ":6667"
-	fmt.Println(os.Args)
-	if len(os.Args) < 2 {
+	var port int
+	var server bool
+	flag.IntVar(&port, "port", 6667, "A listener port")
+    flag.BoolVar(&server, "server", true, "Define a server teecp instance")
+	flag.Parse()
+
+	if server {
 		serverTeecp(port)
 	} else {
 		listenerTeecp(port)
 	}
 }
 
-func listenerTeecp(port string) {
-	conn, err := net.Dial("tcp", fmt.Sprintf("localhost%s", port))
+func listenerTeecp(port int) {
+	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("Could not open socket to port %s\n", port))
+		os.Stderr.WriteString(fmt.Sprintf("Could not open socket to port %d\n", port))
 		os.Exit(1)
 	}
 	defer conn.Close()
@@ -39,7 +44,7 @@ func listenerTeecp(port string) {
 	}
 }
 
-func serverTeecp(port string) {
+func serverTeecp(port int) {
 	var teecp tcp.TeeCPList = tcp.TeeCPList{}
 
 	tcp.Attach(&teecp, func(msg string) bool {
@@ -47,10 +52,10 @@ func serverTeecp(port string) {
 		return true
 	})
 
-	ln, err := net.Listen("tcp", port)
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("Could not open socket to port %s\n", port))
+		os.Stderr.WriteString(fmt.Sprintf("Could not open socket to port %d\n", port))
 		os.Exit(1)
 	}
 	defer ln.Close()


### PR DESCRIPTION
Add a simple way to user define port and server or client with flags.

`—server=false` define a client instance
`—port number` define a port number to use on listener