### PR TITLE
Add tests for the new flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.22.1'
-      - run: go build && go test -v -parallel 4
+      - run: go test -v -cover
   build:
     name: Build binary
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.22.1'
-      - run: go test -v -cover
+      - run: go build && go test -v -parallel 4
   build:
     name: Build binary
     runs-on: 'ubuntu-latest'

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,18 @@
 module github.com/jeffque/teecp
 
-go 1.22.1
+go 1.22.5
+
+replace github.com/jeffque/teecp/teecp_cli => ./teecp_cli
+
+replace github.com/jeffque/teecp/teecp_server => ./teecp_server
+
+replace github.com/jeffque/teecp/teecp_client => ./teecp_client
+
+replace github.com/jeffque/teecp/teecp => ./teecp
+
+require (
+	github.com/jeffque/teecp/teecp_client v0.0.0-00010101000000-000000000000
+	github.com/jeffque/teecp/teecp_server v0.0.0-00010101000000-000000000000
+)
+
+require github.com/jeffque/teecp/teecp v0.0.0-00010101000000-000000000000 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"log"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestShouldTryToConnectDefaultPort(t *testing.T) {
+	buildProgram()
+	client := exec.Command("./teecp.exe", "--client")
+	output, err := client.CombinedOutput()
+
+	if err == nil {
+		t.Error("must show error when connecting to a port without server")
+	}
+
+	if pattern := regexp.MustCompile("6667"); !pattern.Match(output) {
+		t.Error("the default port that it tries should be 6667")
+	}
+}
+
+func TestShouldWaitForAtLeast1Second(t *testing.T) {
+	buildProgram()
+
+	client := exec.Command("./teecp.exe", "--client", "--wait-connection")
+	output, err := client.CombinedOutput()
+
+	if err == nil {
+		t.Error("must show error when connecting to a port without server")
+	}
+
+	if pattern := regexp.MustCompile("6667"); !pattern.Match(output) {
+		t.Error("the default port that it tries should be 6667")
+	}
+
+	outputLines := strings.Split(string(output), "\n")
+	if len(outputLines) != 4 {
+		t.Error("should have tried 2 times to connect")
+	}
+
+	client.ProcessState.UserTime()
+}
+
+func buildProgram() {
+	buildCommand := exec.Command("go", "build")
+	if err := buildCommand.Run(); err != nil {
+		log.Fatal("could not build program")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestShouldTryToConnectDefaultPort(t *testing.T) {
-	buildProgram()
+	t.Parallel()
 	client := exec.Command("./teecp.exe", "--client")
 	output, err := client.CombinedOutput()
 
@@ -23,10 +24,11 @@ func TestShouldTryToConnectDefaultPort(t *testing.T) {
 }
 
 func TestShouldWaitForAtLeast1Second(t *testing.T) {
-	buildProgram()
-
+	t.Parallel()
 	client := exec.Command("./teecp.exe", "--client", "--wait-connection")
+	start := time.Now()
 	output, err := client.CombinedOutput()
+	runDuration := time.Since(start).Seconds()
 
 	if err == nil {
 		t.Error("must show error when connecting to a port without server")
@@ -36,17 +38,77 @@ func TestShouldWaitForAtLeast1Second(t *testing.T) {
 		t.Error("the default port that it tries should be 6667")
 	}
 
-	outputLines := strings.Split(string(output), "\n")
+	outputLines := strings.Split(strings.TrimSpace(string(output)), "\n")
 	if len(outputLines) != 4 {
 		t.Error("should have tried 2 times to connect")
 	}
 
-	client.ProcessState.UserTime()
+	if runDuration < 1.0 || runDuration > 1.05 {
+		t.Error("the default wait time should be around 1 second")
+	}
 }
 
-func buildProgram() {
-	buildCommand := exec.Command("go", "build")
-	if err := buildCommand.Run(); err != nil {
-		log.Fatal("could not build program")
+func TestShouldWaitForDefinedDuration(t *testing.T) {
+	t.Parallel()
+	var waitSeconds float64 = 2.0
+	client := exec.Command("./teecp.exe", "--client", fmt.Sprintf("--wait-connection=%.f", waitSeconds))
+	start := time.Now()
+	output, err := client.CombinedOutput()
+	runDuration := time.Since(start).Seconds()
+
+	if err == nil {
+		t.Error("client should show error when not connecting")
+	}
+
+	if lines := strings.Split(strings.TrimSpace(string(output)), "\n"); len(lines) != 6 {
+		t.Error("should output retry info for 3 times")
+	}
+
+	if runDuration < waitSeconds || runDuration > (waitSeconds+0.2) {
+		t.Errorf("client should wait for about %.f seconds", waitSeconds)
+	}
+}
+
+func TestUnderstandTimeUnitsWhenWaiting(t *testing.T) {
+	t.Parallel()
+	var waitMicroseconds int64 = 1000
+	client := exec.Command(
+		"./teecp.exe",
+		"--client",
+		fmt.Sprintf("--wait-connection=%dms", waitMicroseconds),
+		"--retry-interval=500ms",
+	)
+	start := time.Now()
+	output, err := client.CombinedOutput()
+	runDuration := time.Since(start).Milliseconds()
+
+	if err == nil {
+		t.Error("client should show error when not connecting")
+	}
+
+	if lines := strings.Split(strings.TrimSpace(string(output)), "\n"); len(lines) != 6 {
+		t.Error("should output retry info for 3 times")
+	}
+
+	if runDuration < waitMicroseconds || runDuration > (waitMicroseconds+60) {
+		t.Errorf("client should wait for about 1 second")
+	}
+}
+
+func TestSettingRetryIntervalWithoutWaitingShouldHaveNoEffect(t *testing.T) {
+	t.Parallel()
+	client := exec.Command(
+		"./teecp.exe",
+		"--client",
+		"--retry-interval=500ms",
+	)
+	output, err := client.CombinedOutput()
+
+	if err == nil {
+		t.Error("client should show error when not connecting")
+	}
+
+	if lines := strings.Split(strings.TrimSpace(string(output)), "\n"); len(lines) != 1 {
+		t.Error("should only have errored 1 time")
 	}
 }

--- a/teecp/go.mod
+++ b/teecp/go.mod
@@ -1,0 +1,3 @@
+module github.com/jeffque/teecp/teecp
+
+go 1.22.5

--- a/teecp/teecp_test.go
+++ b/teecp/teecp_test.go
@@ -1,0 +1,7 @@
+package teecp_test
+
+import "testing"
+
+func TestServer(t *testing.T) {
+	t.Fatal(`Shipt`)
+}

--- a/teecp_client/go.mod
+++ b/teecp_client/go.mod
@@ -1,0 +1,3 @@
+module github.com/jeffque/teecp/teecp_client
+
+go 1.22.5

--- a/teecp_client/teecp_client.go
+++ b/teecp_client/teecp_client.go
@@ -1,0 +1,64 @@
+package teecp_client
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+)
+
+func connectSocket(port int, waitConnection time.Duration, retryInterval time.Duration) (net.Conn, error) {
+	var conn net.Conn
+	var err error
+	start := time.Now()
+
+	if waitConnection > 0 {
+		fmt.Fprintf(os.Stderr, "Trying to connect to server for %f seconds\n", waitConnection.Seconds())
+	}
+
+	for {
+		conn, err = net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+
+		if waitConnection == 0 || time.Since(start) > waitConnection || waitConnection < retryInterval {
+			break
+		}
+
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+
+		fmt.Fprintf(os.Stderr, "Waiting for %f seconds\n", retryInterval.Seconds())
+		time.Sleep(retryInterval)
+	}
+
+	return conn, err
+}
+
+func ListenerTeecp(port int, waitConnection time.Duration, retryInterval time.Duration) error {
+	conn, err := connectSocket(port, waitConnection, retryInterval)
+
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	for {
+		txt, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("error reading stream: %w\nclosing", err)
+		}
+
+		// Fprint not strictly needed, but doing so for consistency.
+		fmt.Fprint(os.Stdout, txt)
+	}
+
+	return nil
+}

--- a/teecp_server/go.mod
+++ b/teecp_server/go.mod
@@ -1,0 +1,7 @@
+module github.com/jeffque/teecp/teecp_server
+
+go 1.22.5
+
+replace github.com/jeffque/teecp/teecp => ../teecp
+
+require github.com/jeffque/teecp/teecp v0.0.0-00010101000000-000000000000

--- a/teecp_server/teecp_server.go
+++ b/teecp_server/teecp_server.go
@@ -1,0 +1,76 @@
+package teecp_server
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+
+	"github.com/jeffque/teecp/teecp"
+)
+
+func ServerTeecp(port int) error {
+	// When creating the teecp.Clients, always have a local client so we can see the echo.
+	clients := teecp.Clients{}
+	clients.Attach(func(msg string) bool {
+		fmt.Print(msg)
+		return true
+	})
+
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return fmt.Errorf("could not open socket to port %d: %w", port, err)
+	}
+	fmt.Printf("Listening at %d", port)
+
+	defer ln.Close()
+
+	// Create a channel so we can signal to the goroutine that it can quit.
+	quit := make(chan bool)
+	defer close(quit)
+
+	go acceptNewConns(ln, &clients, quit)
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		txt, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("error reading form stdin: %w\nclosing teecp", err)
+		}
+		clients.Broadcast(txt)
+	}
+
+	return nil
+}
+
+func acceptNewConns(ln net.Listener, clients *teecp.Clients, quit chan bool) {
+	// We need the label to break out of the for loop because otherwise we would only break out of the select.
+LOOP:
+	for {
+		select {
+		case <-quit:
+			// Break out of the loop.
+			break LOOP
+		default:
+			conn, err := ln.Accept()
+			if err != nil {
+				os.Stderr.WriteString(fmt.Sprintf("tried to connect but failed %s\n", err.Error()))
+				return
+			}
+
+			// Add the connection as a client.
+			clients.Attach(func(msg string) bool {
+				if _, err := fmt.Fprint(conn, msg); err != nil {
+					conn.Close()
+					return false
+				}
+				return true
+			})
+		}
+	}
+}


### PR DESCRIPTION
I'm adding tests for the new flags I added in the last PR. The way I got to test them was running the executable as a blackbox and measuring the time and checking the outputs. But for them to run the executable must be avaliable in the test working dir so I need the workflow run command to be changed to like so:

```diff
-       - run: go test -v -cover
+      - run: go build && go test -v -parallel 4
```

The problem is that it doesnt trigger the code coverage. Maybe we can test the code directly them later